### PR TITLE
Add import and tweak build parameters

### DIFF
--- a/image/qdrawhelper.cpp
+++ b/image/qdrawhelper.cpp
@@ -24,6 +24,7 @@
 ****************************************************************************/
 
 #include <qglobal.h>
+#include <cstdint>
 
 #include <qatomic.h>
 #include <private/qdrawhelper_p.h>

--- a/thirdparty/xcb/BUSY
+++ b/thirdparty/xcb/BUSY
@@ -27,6 +27,6 @@ let sources * : SourceSet {
 		./libxcb/xinerama.c
 		./libxcb/xkb.c
 	]
-	.defines += "XCB_USE_RENDER"
+	.defines += [ "XCB_USE_RENDER" "HAVE_VASPRINTF" ]
 	.configs += [ ^_core_config config ]
 }

--- a/thirdparty/xkbcommon/BUSY
+++ b/thirdparty/xkbcommon/BUSY
@@ -39,7 +39,7 @@ let sources * : SourceSet {
 		./src/xkbcomp/parser.c
 	]
 	if (target_toolchain == `gcc) || (target_toolchain == `clang) {
-		.cflags_c += [ "-std=c99" "-w" ] 
+		.cflags_c += [ "-std=gnu" "-w" ] 
 	}
 	.defines += [
 		"DFLT_XKB_CONFIG_ROOT=\"/usr/share/X11/xkb\""


### PR DESCRIPTION
I Followed the instructions to build https://github.com/rochus-keller/Cedar but  I needed to change a few things in LeanQT to get it building on Ubuntu 24.10 using GCC 14.1.0

I'm not sure if any of this changes are really necessary, but if I don't change the C standard to gnu, stdio.h won't define _asprintf_ in one place and _vasprintf_ on another. And without the include I get errors that  _uintptr_t_ is undefined.

Unrelated suggestion: You should strongly advise on the README of project using LeanQT that people consider using LeanCreator, instead of using BUSY (directly?) to get the benefits of compiling in parallel.